### PR TITLE
GREEN-54 add verification for savedActiveNode before saving in local …

### DIFF
--- a/src/utils/fetch-network-data.ts
+++ b/src/utils/fetch-network-data.ts
@@ -132,7 +132,15 @@ export async function getNewActiveNode(
   }
   savedActiveNode =
     nodeList.nodeList[Math.floor(Math.random() * nodeList.nodeList.length)];
-
+  if (
+    !savedActiveNode ||
+    !savedActiveNode.id ||
+    !savedActiveNode.ip ||
+    !savedActiveNode.port ||
+    !savedActiveNode.publicKey
+  ) {
+    throw new Error('Bad returned savedActiveNode');
+  }
   //Write savedActiveNode to file
   // eslint-disable-next-line security/detect-non-literal-fs-filename
   fs.writeFileSync(


### PR DESCRIPTION
Before using fs.writeFileSync to write into active-node.json validator local file, the structure of savedActiveNode should be verified