### PR TITLE
PM-82: fix: broken cli due to new stake endpoint

### DIFF
--- a/src/utils/fetch-network-data.ts
+++ b/src/utils/fetch-network-data.ts
@@ -396,13 +396,12 @@ export async function fetchStakeParameters(config: networkConfigType) {
   }
 
   const stakeParams = await fetchDataFromNetwork<{
-    stakeRequired: string;
+    stakeRequired: {value: string};
   }>(config, '/stake', data => !data);
   if (!stakeParams) {
     throw new Error("Couldn't fetch stake parameters");
   }
-
-  const stakeRequired = new BN(stakeParams.stakeRequired, 16).toString();
+  const stakeRequired = new BN(stakeParams.stakeRequired.value, 16).toString();
   const cycleDuration = await fetchCycleDuration(config);
   cache.set('stakeParams', stakeRequired, cycleDuration * 1000);
   return {


### PR DESCRIPTION
https://linear.app/shm/issue/PM-82/operator-cli-status-command-errors-displayed-in-output-log-before

The status command was broken due to the /stake endpoint returning a different object than usual. Fixed.