### PR TITLE
RED-176: [Node Validator][UI] Node Validator "Unstake" button is not displayed

### DIFF
--- a/src/node-commands.ts
+++ b/src/node-commands.ts
@@ -421,7 +421,7 @@ export function registerNodeCommands(program: Command) {
       });
     });
 
-    program
+  program
     .command('stake_info')
     .description('Show staking info for a particular EOA account')
     .argument('<address>', 'The EOA address to fetch stake info for')
@@ -432,24 +432,24 @@ export function registerNodeCommands(program: Command) {
       }
 
       try {
-        const eoaData = await fetchEOADetails(config, address);
-        const stakeValue = eoaData?.operatorAccountInfo?.stake?.value;
-        const nominee = eoaData?.operatorAccountInfo?.nominee ?? '';
+        const eoaData = await fetchEOADetails(config, address)
+        const stakeValue = eoaData?.operatorAccountInfo?.stake?.value
+        const nominee = eoaData?.operatorAccountInfo?.nominee ?? ''
 
         // Convert stake value to ether, handling potential hexadecimal input
         const stakeOutput = stakeValue 
           ? ethers.utils.formatEther(
               ethers.BigNumber.from(stakeValue.startsWith('0x') ? stakeValue : '0x' + stakeValue).toString()
             )
-          : '';
+          : ''
       
         console.log(yaml.dump({
           stake: stakeOutput,
           nominee: nominee
         }));
       } catch (error) {
-        console.log(error);
-        console.error(`Error fetching stake details for ${address}: ${error}`);
+        console.log(error)
+        console.error(`Error fetching stake details for ${address}: ${error}`)
       }
     });
 

--- a/src/node-commands.ts
+++ b/src/node-commands.ts
@@ -421,7 +421,7 @@ export function registerNodeCommands(program: Command) {
       });
     });
 
-  program
+    program
     .command('stake_info')
     .description('Show staking info for a particular EOA account')
     .argument('<address>', 'The EOA address to fetch stake info for')
@@ -433,18 +433,23 @@ export function registerNodeCommands(program: Command) {
 
       try {
         const eoaData = await fetchEOADetails(config, address);
-        console.log(
-          yaml.dump({
-            stake: eoaData?.operatorAccountInfo?.stake?.value
-              ? ethers.utils.formatEther(
-                  String(parseInt(eoaData.operatorAccountInfo.stake.value, 16))
-                )
-              : '',
-            nominee: eoaData?.operatorAccountInfo?.nominee ?? '',
-          })
-        );
+        const stakeValue = eoaData?.operatorAccountInfo?.stake?.value;
+        const nominee = eoaData?.operatorAccountInfo?.nominee ?? '';
+
+        // Convert stake value to ether, handling potential hexadecimal input
+        const stakeOutput = stakeValue 
+          ? ethers.utils.formatEther(
+              ethers.BigNumber.from(stakeValue.startsWith('0x') ? stakeValue : '0x' + stakeValue).toString()
+            )
+          : '';
+      
+        console.log(yaml.dump({
+          stake: stakeOutput,
+          nominee: nominee
+        }));
       } catch (error) {
-        console.error(error);
+        console.log(error);
+        console.error(`Error fetching stake details for ${address}: ${error}`);
       }
     });
 


### PR DESCRIPTION
https://linear.app/shm/issue/RED-176/[node-validator][ui]-node-validator-unstake-button-is-not-displayed

***should be merged after https://github.com/shardeum/validator-cli/pull/15

Summary: Fix an issue with parsing large hexadecimal stake values in the stake_info command. 

- Replace parseInt with ethers.BigNumber.from() to handle large numbers, and adds logic to ensure proper '0x' prefixing for hexadecimal interpretation. 
- Change prevents errors when processing stake values and ensures accurate conversion from wei to Ether, improving the reliability of stake information display.
- Add error logging that'll trigger GUI warning since BN error was not showing up