### PR TITLE
Revert "Fix Node commands on the Validator CLI"

### DIFF
--- a/src/node-commands.ts
+++ b/src/node-commands.ts
@@ -273,21 +273,13 @@ fs.writeFileSync(
   JSON.stringify(config, undefined, 2)
 );
 
-function validateNoUnexpectedArgs(command: Command, expectedArgs: number, errorMessage: string) {
-  if (command.args.length > expectedArgs) {
-    console.error(`Error: Unexpected arguments provided. ${errorMessage}`);
-    process.exit(1);
-  }
-}
-
 export function registerNodeCommands(program: Command) {
   program
     .command('status')
     .description(
       'Show if validator is running or not; also the port and URL to connect to it'
     )
-    .action(async (options, command) => {
-      validateNoUnexpectedArgs(command, 0, 'The "status" command does not accept any additional arguments.');
+    .action(async () => {
       pm2.describe('validator', async (err, descriptions) => {
         // PM2 not reachable
         if (err) {
@@ -433,8 +425,7 @@ export function registerNodeCommands(program: Command) {
     .command('stake_info')
     .description('Show staking info for a particular EOA account')
     .argument('<address>', 'The EOA address to fetch stake info for')
-    .action(async (options, command, address) => {
-      validateNoUnexpectedArgs(command, 0, 'The "stake_info" command does not accept any additional arguments.');
+    .action(async address => {
       if (!ethers.utils.isAddress(address)) {
         console.error('Invalid address entered');
         return;
@@ -465,8 +456,7 @@ export function registerNodeCommands(program: Command) {
   program
     .command('start')
     .description('Starts the validator')
-    .action((options, command) => {
-      validateNoUnexpectedArgs(command, 0, 'The "start" command does not accept any additional arguments.');
+    .action(() => {
       // Run the validators clean script
 
       execFile(
@@ -520,8 +510,7 @@ export function registerNodeCommands(program: Command) {
       '-f, --force',
       'stops the node without prompting for confirmation even if it is participating and could get slashed'
     )
-    .action((options, command) => {
-      validateNoUnexpectedArgs(command, 0, 'The "stop" command only accepts the "-f" or "--force" option.');
+    .action(options => {
       function stopNode() {
         pm2.stop('validator', err => {
           if (err) console.error(err);
@@ -589,8 +578,7 @@ export function registerNodeCommands(program: Command) {
     .description(
       'Stake the set amount of SHM at the stake address. Rewards will be sent to set reward address.'
     )
-    .action(async(options, command, stakeValue) => {
-      validateNoUnexpectedArgs(command, 0, 'The "stake" command only accepts a single argument for the stake value.');
+    .action(async stakeValue => {
       //TODO should we handle consecutive stakes?
 
       // Fetch the public key from secrets.json
@@ -760,8 +748,7 @@ export function registerNodeCommands(program: Command) {
       '-f, --force',
       'Force unstake in case the node is stuck, will forfeit rewards'
     )
-    .action(async (options, command) => {
-      validateNoUnexpectedArgs(command, 0, 'The "unstake" command only accepts the "-f" or "--force" option.');
+    .action(async options => {
       try {
         if (options.force) {
           const answer = await getUserInput(
@@ -799,8 +786,7 @@ export function registerNodeCommands(program: Command) {
   program
     .command('update')
     .description('Update the CLI and the GUI')
-    .action((options, command) => {
-      validateNoUnexpectedArgs(command, 0, 'The "update" command does not accept any additional arguments.');
+    .action(() => {
       exec(
         'sh update.sh',
         {cwd: path.join(__dirname, '../..')},
@@ -831,8 +817,7 @@ export function registerNodeCommands(program: Command) {
     .description(
       'Shows the installed version, latest version and minimum version of the operator dashboard'
     )
-    .action(async (options, command) => {
-      validateNoUnexpectedArgs(command, 0, 'The "version" command does not accept any additional arguments.');
+    .action(async () => {
       const validatorVersions = await fetchValidatorVersions(config);
       if (!validatorVersions) {
         throw new Error("Couldn't fetch validator versions");
@@ -875,8 +860,7 @@ export function registerNodeCommands(program: Command) {
     .description(
       'Show statistics like TPS, active nodes etc. about the network'
     )
-    .action(async (options, command) => {
-      validateNoUnexpectedArgs(command, 0, 'The "network-stats" command does not accept any additional arguments.');
+    .action(async () => {
       pm2.describe('validator', async (err, [descriptions]) => {
         if (!err) {
           const networkStats = await getNetworkParams(config, descriptions);
@@ -890,8 +874,7 @@ export function registerNodeCommands(program: Command) {
   program
     .command('node-settings')
     .description('Display node settings')
-    .action((options, command) => {
-      validateNoUnexpectedArgs(command, 0, 'The "node-settings" command does not accept any additional arguments.');
+    .action(() => {
       const settings = getNodeSettings();
       console.log(
         yaml.dump({
@@ -990,8 +973,7 @@ export function registerNodeCommands(program: Command) {
     .description(
       'To autostart the node after being rotated out. Set autostart to true or false'
     )
-    .action(async (options, command, autostart: string) => {
-      validateNoUnexpectedArgs(command, 0, 'The "auto_restart" command does not accept any additional arguments.');
+    .action((autostart: string) => {
       const input = autostart.toLowerCase();
       if (input !== 'true' && input !== 'false') {
         console.error('Invalid input. Please enter true or false');


### PR DESCRIPTION
Reverts shardeum/validator-cli#13 which introduced a bug causing stake_info to fail
```
$ operator-cli stake_info 0xb6F1507848661Ee0D35a2e4E1c9BB6D94ab9C221
/home/node/app/cli/build/src/node-commands.js:201
    if (command.args.length > expectedArgs) {
                     ^

TypeError: Cannot read properties of undefined (reading 'length')
    at validateNoUnexpectedArgs (/home/node/app/cli/build/src/node-commands.js:201:22)
    at Command.<anonymous> (/home/node/app/cli/build/src/node-commands.js:334:9)
    at Command.listener [as _actionHandler] (/home/node/app/cli/node_modules/commander/lib/command.js:482:17)
    at /home/node/app/cli/node_modules/commander/lib/command.js:1283:65
    at Command._chainOrCall (/home/node/app/cli/node_modules/commander/lib/command.js:1177:12)
    at Command._parseCommand (/home/node/app/cli/node_modules/commander/lib/command.js:1283:27)
    at /home/node/app/cli/node_modules/commander/lib/command.js:1081:27
    at Command._chainOrCall (/home/node/app/cli/node_modules/commander/lib/command.js:1177:12)
    at Command._dispatchSubcommand (/home/node/app/cli/node_modules/commander/lib/command.js:1077:23)
    at Command._parseCommand (/home/node/app/cli/node_modules/commander/lib/command.js:1248:19)

Node.js v18.16.1
```