### PR TITLE
RED-292: Validator GUI doesn't show the Version info

### DIFF
--- a/src/utils/project-data.ts
+++ b/src/utils/project-data.ts
@@ -9,13 +9,13 @@ const GUI_LOCAL_PATH = path.join(__dirname, '../../../../gui');
 const VALIDATOR_LOCAL_PATH = path.join(__dirname, '../../../../validator');
 
 export async function getLatestCliVersion() {
-  const packageJsonURI = `https://raw.githubusercontent.com/shardeum/validator-cli/main/package.json`;
+  const packageJsonURI = `https://raw.githubusercontent.com/shardeum/validator-cli/dev/package.json`;
   const json = await axios.get<{version: string}>(packageJsonURI);
   return json.data.version;
 }
 
 export async function getLatestGuiVersion() {
-  const packageJsonURI = `https://raw.githubusercontent.com/shardeum/validator-gui/main/package.json`;
+  const packageJsonURI = `https://raw.githubusercontent.com/shardeum/validator-gui/dev/package.json`;
   const json = await axios.get<{version: string}>(packageJsonURI);
   return json.data.version;
 }


### PR DESCRIPTION
https://linear.app/shm/issue/RED-292/validator-gui-doesnt-show-the-version-info

Summary: Update package.json URIs for CLI and GUI to dev branch. 

- was previously `https://raw.githubusercontent.com/shardeum/validator-cli/main/package.json` and there's not a main branch anymore

![image](https://github.com/user-attachments/assets/32547745-d867-4766-a6c7-dfbbdfbc3e02)
![image](https://github.com/user-attachments/assets/cdea5e31-4387-477a-b1f0-d947fb9b2035)
![image](https://github.com/user-attachments/assets/99514da4-8827-4f03-b063-93bc056b1f87)
