### PR TITLE
RED-302: Set Password Command Fails to Change Password Despite Valid Input

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,9 +122,25 @@ npm run compile
    ```
 
 3. Set GUI password:
+   
+   Interactive mode (recommended for direct use):
    ```bash
-   operator-cli gui set password <your-password>
+   operator-cli gui set password
    ```
+   You will be prompted to enter the password securely.
+
+   Non-interactive mode (for scripts or programmatic use):
+   ```bash
+   echo 'YourStr0ng$P@ssw0rd!' | operator-cli gui set password
+   ```
+   Note: Be cautious when using this method as the password will be visible in your command history.
+
+   Password requirements:
+   - Minimum 8 characters
+   - At least 1 lowercase letter
+   - At least 1 uppercase letter
+   - At least 1 number
+   - At least 1 special character from: !@#$%^&*()_+*$
 
 ### Advanced Usage
 

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ npm run compile
 
    Non-interactive mode (for scripts or programmatic use):
    ```bash
-   echo 'YourStr0ng$P@ssw0rd!' | operator-cli gui set password
+   echo '<Your Password>' | operator-cli gui set password
    ```
    Note: Be cautious when using this method as the password will be visible in your command history.
 


### PR DESCRIPTION
https://linear.app/shm/issue/RED-302/[new-validator-gui]-set-password-command-fails-to-change-password
Fix password set with `$`, enhance security, update readme

Summary: Enhance password setting security and usability

- Implement `interactive mode` to remove password from command-line arguments to avoid shell misinterpretation with special characters (i.e. $)
    -  also prevents exposure in history and logs when using `interactive mode` 
- Add `non-interactive mode` for scripted password setting via piped input to avoid shell misinterpretation
    - More secure than command-line arguments (not visible in process lists)
- Maintain compatibility with existing systems while improving security
- added success log after password is set