### PR TITLE
Red 318: Stake info throws repeated error if connected wallet has no activity on the network

### DIFF
--- a/src/node-commands.ts
+++ b/src/node-commands.ts
@@ -355,7 +355,7 @@ export function registerNodeCommands(program: Command) {
           const lockedStakeStr = accountInfo.lockedStake
             ? ethers.utils.formatEther(accountInfo.lockedStake)
             : '';
-          let nodeStatus = nodeInfo.status;
+          let nodeStatus = nodeInfo?.status;
           if (nodeStatus === 'initializing')
             nodeStatus =
               lockedStakeStr === '0.0' ? 'need-stake' : 'waiting-for-network';
@@ -433,6 +433,13 @@ export function registerNodeCommands(program: Command) {
 
       try {
         const eoaData = await fetchEOADetails(config, address)
+
+        // Handle the case where the account does not exist
+        if (eoaData == null) {
+          const error = new Error(`No stake information found`)
+          throw error;
+        }
+
         const stakeValue = eoaData?.operatorAccountInfo?.stake?.value
         const nominee = eoaData?.operatorAccountInfo?.nominee ?? ''
 

--- a/src/node-commands.ts
+++ b/src/node-commands.ts
@@ -436,7 +436,7 @@ export function registerNodeCommands(program: Command) {
 
         // Case where query does not error and no stake info is found
         if (eoaData == null) {
-          const error = new Error(`No stake information found`)
+          const error = new Error(`No stake information found due to no previous stake or never funded`)
           throw error;
         }
 

--- a/src/node-commands.ts
+++ b/src/node-commands.ts
@@ -434,7 +434,7 @@ export function registerNodeCommands(program: Command) {
       try {
         const eoaData = await fetchEOADetails(config, address)
 
-        // Handle the case where the account does not exist
+        // Case where query does not error and no stake info is found
         if (eoaData == null) {
           const error = new Error(`No stake information found`)
           throw error;

--- a/src/utils/fetch-network-data.ts
+++ b/src/utils/fetch-network-data.ts
@@ -349,8 +349,8 @@ export async function fetchEOADetails(
 
     return eoaParams?.account;
   } catch (error) {
-    console.error(`Error fetching EOA details for ${eoaAddress}:`, error);
-    return null;
+    console.error(error);
+    return error instanceof Error ? error : new Error(String(error));
   }
 }
 

--- a/src/utils/fetch-network-data.ts
+++ b/src/utils/fetch-network-data.ts
@@ -36,7 +36,7 @@ let savedActiveNode:
   
   interface ResponseData {
     account?: Account | null;
-    [key: string]: any;
+    [key: string]: string | number | boolean | null | undefined | Account;
   }
 
 /**
@@ -103,7 +103,7 @@ async function fetchDataFromNetwork<T>(
       // set data to null and status to 500 to indicate that the request failed
       data = {data: null, status: 500};
     }
-  } while ((data.status === 500 || callback(data.data)) && retries--);
+  } while ((data.status === 500 || callback(data.data as {[id: string]: string})) && retries--);
 
   if (retries < 0) {
     // figure out why we ran out of retries before throwing our error


### PR DESCRIPTION
https://linear.app/shm/issue/RED-318/[new-validator-design]-stake-info-throws-repeated-error-if-connected

Summary: 

- **Issue**: Stake info command throws repeated errors for unfunded/inactive accounts causing GUI to repeatedly warn about error.
- **Root Cause**: `fetchEOADetails` function wasn't properly handling cases where an account doesn't exist on the network

- **Changes**:
  - Enhanced error handling in `fetchEOADetails` function
  - Improved `fetchDataFromNetwork` to detect "account not found" scenarios instead of just `unknown reason`
  - Updated `stake_info` command to handle and display errors gracefully

- **Improvements**:
  - CLI now provides more informative output for non-existent accounts
  - GUI no longer floods with errors for unfunded accounts
  - Consistent error logs across CLI and GUI

