### PR TITLE
SHARD-1202: Use 6 gigs of memory for node

### DIFF
--- a/auto-restart-controller.js
+++ b/auto-restart-controller.js
@@ -32,6 +32,7 @@ fs.watch(configFilePath, (eventType, filename) => {
 const startApp = () => {
   const app = fork(path.join(__dirname, '../validator/dist/src/index.js'), {
     cwd: path.join(__dirname, './build'),
+    execArgv: ['--max-old-space-size=6144'],
   });
 
   app.on('exit', code => {


### PR DESCRIPTION
https://linear.app/shm/issue/SHARD-1202/launch-nodes-with-max-old-space-size=6144