### PR TITLE
SHARD-2132: Improve unstake ux

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -15,10 +15,10 @@ module.exports = {
   setupFilesAfterEnv: ['<rootDir>/test/setup.ts'],
   coverageThreshold: {
     global: {
-      branches: 5.68,
-      functions: 2.91,
-      lines: 3.22,
-      statements: 3.18,
+      branches: 5.0,
+      functions: 2.7,
+      lines: 3.0,
+      statements: 3.0,
     },
   },
 }

--- a/src/node-commands.ts
+++ b/src/node-commands.ts
@@ -249,7 +249,7 @@ fs.writeFileSync(path.join(__dirname, `../${File.CONFIG}`), JSON.stringify(confi
 
 let lastFailedUnstakeAttempt: number | null = null
 const RETRY_INTERVAL_MS = 2 * 60 * 1000 // 2 minutes in milliseconds
-let retryInterval: NodeJS.Timeout | null = null
+const retryInterval: NodeJS.Timeout | null = null
 
 async function getPrivateKey(): Promise<string> {
   let privateKey = await getUserInput('Please enter your private key: ')

--- a/src/node-commands.ts
+++ b/src/node-commands.ts
@@ -45,6 +45,7 @@ import logger from './utils/logger'
 import { isIP } from 'net'
 import Ajv from 'ajv'
 import { VALIDATOR_CLEAN_PATH } from './projectFlags'
+
 type VersionStats = {
   runningCliVersion: string
   runningCliBranch: string
@@ -294,18 +295,18 @@ async function createUnstakeTransaction(walletWithProvider: ethers.Wallet, optio
   }
 }
 
-function getRunningUnstake(): {timestamp: number, hash: string} | null {
+function getRunningUnstake(): { timestamp: number; hash: string } | null {
   try {
     if (fs.existsSync(path.join(__dirname, `../${File.UNSTAKE_REQUEST}`))) {
       return JSON.parse(
         // eslint-disable-next-line security/detect-non-literal-fs-filename
-        fs.readFileSync(path.join(__dirname, `../${File.UNSTAKE_REQUEST}`)).toString(),
-      );
+        fs.readFileSync(path.join(__dirname, `../${File.UNSTAKE_REQUEST}`)).toString()
+      )
     }
   } catch (e) {
-    console.error('Error reading unstake file:', e);
+    console.error('Error reading unstake file:', e)
   }
-  return null;
+  return null
 }
 
 function addUnstakeToFile(timestamp: number, hash: string) {
@@ -384,14 +385,17 @@ function startRetryProcess(walletWithProvider: ethers.Wallet, options: { force?:
   }
 }
 
-async function unstake(options: { force?: boolean, ignoreRateLimit?: boolean }) {
+async function unstake(options: { force?: boolean; ignoreRateLimit?: boolean }) {
   try {
     const privateKey = await getPrivateKey()
     const provider = new ethers.providers.JsonRpcProvider(rpcServer.url)
     const walletWithProvider = new ethers.Wallet(privateKey, provider)
 
     const runningUnstake = getRunningUnstake()
-    const delay = !options?.ignoreRateLimit && runningUnstake?.timestamp ? RETRY_INTERVAL_MS - (Date.now() - runningUnstake.timestamp) : 0
+    const delay =
+      !options?.ignoreRateLimit && runningUnstake?.timestamp
+        ? RETRY_INTERVAL_MS - (Date.now() - runningUnstake.timestamp)
+        : 0
     startRetryProcess(walletWithProvider, options, delay > 0 ? delay : 0)
   } catch (error) {
     console.error(error)

--- a/src/node-commands.ts
+++ b/src/node-commands.ts
@@ -310,14 +310,14 @@ function startRetryInterval(walletWithProvider: ethers.Wallet, options: { force?
     try {
       const txDetails = await createUnstakeTransaction(walletWithProvider, options)
       console.log('Retrying unstake with data:', txDetails)
-      await executeUnstakeTransaction(walletWithProvider, txDetails)
-
-      if (retryInterval) {
-        clearInterval(retryInterval)
-        retryInterval = null
-      }
-      lastFailedUnstakeAttempt = null
-      console.log('Unstake successful! Rate limit lifted.')
+      executeUnstakeTransaction(walletWithProvider, txDetails).then(() => {
+        if (retryInterval) {
+          clearInterval(retryInterval)
+          retryInterval = null
+        }
+        lastFailedUnstakeAttempt = null
+        console.log('Unstake successful! Rate limit lifted.')
+      })
     } catch (error) {
       console.error('Retry attempt failed:', error)
     }
@@ -344,11 +344,7 @@ async function unstake(options: { force?: boolean }) {
     const provider = new ethers.providers.JsonRpcProvider(rpcServer.url)
     const walletWithProvider = new ethers.Wallet(privateKey, provider)
 
-    if (checkRateLimit()) {
-      console.log('Will automatically retry the transaction every 2 minutes...')
-      startRetryInterval(walletWithProvider, options)
-      return
-    }
+    startRetryInterval(walletWithProvider, options)
 
     const txDetails = await createUnstakeTransaction(walletWithProvider, options)
     await executeUnstakeTransaction(walletWithProvider, txDetails)

--- a/src/node-commands.ts
+++ b/src/node-commands.ts
@@ -317,9 +317,9 @@ function startRetryInterval(walletWithProvider: ethers.Wallet, options: { force?
         retryInterval = null
       }
       lastFailedUnstakeAttempt = null
+      console.log('Unstake successful! Rate limit lifted.')
     } catch (error) {
       console.error('Retry attempt failed:', error)
-      lastFailedUnstakeAttempt = Date.now()
     }
   }, RETRY_INTERVAL_MS)
 }
@@ -354,7 +354,9 @@ async function unstake(options: { force?: boolean }) {
     await executeUnstakeTransaction(walletWithProvider, txDetails)
   } catch (error) {
     console.error(error)
-    lastFailedUnstakeAttempt = Date.now()
+    if (lastFailedUnstakeAttempt === null) {
+      lastFailedUnstakeAttempt = Date.now()
+    }
   }
 }
 

--- a/src/node-commands.ts
+++ b/src/node-commands.ts
@@ -247,7 +247,6 @@ const dashboardPackageJson = JSON.parse(readFileSync(path.join(__dirname, '../..
 fs.writeFileSync(path.join(__dirname, `../${File.CONFIG}`), JSON.stringify(config, undefined, 2))
 
 let lastFailedUnstakeAttempt: number | null = null
-const UNSTAKE_RATE_LIMIT_MS = 5 * 60 * 1000 // 5 minutes in milliseconds
 const RETRY_INTERVAL_MS = 2 * 60 * 1000 // 2 minutes in milliseconds
 let retryInterval: NodeJS.Timeout | null = null
 
@@ -295,59 +294,105 @@ async function createUnstakeTransaction(walletWithProvider: ethers.Wallet, optio
   }
 }
 
+function getRunningUnstake(): {timestamp: number, hash: string} | null {
+  try {
+    if (fs.existsSync(path.join(__dirname, `../${File.UNSTAKE_REQUEST}`))) {
+      return JSON.parse(
+        // eslint-disable-next-line security/detect-non-literal-fs-filename
+        fs.readFileSync(path.join(__dirname, `../${File.UNSTAKE_REQUEST}`)).toString(),
+      );
+    }
+  } catch (e) {
+    console.error('Error reading unstake file:', e);
+  }
+  return null;
+}
+
+function addUnstakeToFile(timestamp: number, hash: string) {
+  try {
+    const runningUnstake = { timestamp, hash }
+    // eslint-disable-next-line security/detect-non-literal-fs-filename
+    fs.writeFileSync(path.join(__dirname, `../${File.UNSTAKE_REQUEST}`), JSON.stringify(runningUnstake, undefined, 2))
+  } catch (e) {
+    console.error('Error writing unstake file:', e)
+  }
+}
+
+function removeUnstakeFile() {
+  try {
+    // eslint-disable-next-line security/detect-non-literal-fs-filename
+    fs.unlinkSync(path.join(__dirname, `../${File.UNSTAKE_REQUEST}`))
+  } catch (e) {
+    console.error('Error removing unstake file:', e)
+  }
+}
+
 async function executeUnstakeTransaction(walletWithProvider: ethers.Wallet, txDetails: any) {
   const { hash, data, wait } = await walletWithProvider.sendTransaction(txDetails)
+  addUnstakeToFile(Date.now(), hash)
   console.log('TX RECEIPT: ', { hash, data })
   const txConfirmation = await wait()
   console.log('TX CONFIRMED: ', txConfirmation)
   return txConfirmation
 }
 
-function startRetryInterval(walletWithProvider: ethers.Wallet, options: { force?: boolean }) {
-  if (retryInterval) return
-
-  retryInterval = setInterval(async () => {
+function startRetryProcess(walletWithProvider: ethers.Wallet, options: { force?: boolean }, initialDelay = 0) {
+  if (initialDelay > 0) {
+    console.log(`Rate limiting unstaking. Next unstake attempt will start in ${initialDelay / 1000} seconds...`)
+  }
+  let retryTimeoutId: NodeJS.Timeout | null = null
+  const attemptUnstake = async () => {
     try {
       const txDetails = await createUnstakeTransaction(walletWithProvider, options)
-      console.log('Retrying unstake with data:', txDetails)
-      executeUnstakeTransaction(walletWithProvider, txDetails).then(() => {
-        if (retryInterval) {
-          clearInterval(retryInterval)
-          retryInterval = null
-        }
-        lastFailedUnstakeAttempt = null
-        console.log('Unstake successful! Rate limit lifted.')
-      })
+      console.log('Unstake with data:', txDetails)
+
+      // Always schedule the next retry before executing the transaction
+      retryTimeoutId = setTimeout(attemptUnstake, RETRY_INTERVAL_MS)
+
+      // Then try the transaction
+      executeUnstakeTransaction(walletWithProvider, txDetails)
+        .then(() => {
+          // Only if successful, cancel the next retry
+          if (retryTimeoutId) {
+            clearTimeout(retryTimeoutId)
+            retryTimeoutId = null
+          }
+          removeUnstakeFile()
+          lastFailedUnstakeAttempt = null
+          console.log('Unstake successful! Rate limit lifted.')
+        })
+        .catch((error) => {
+          console.error('Unstake execution failed:', error)
+          // Let the already scheduled retry run
+        })
     } catch (error) {
       console.error('Retry attempt failed:', error)
+      // Schedule next retry
+      retryTimeoutId = setTimeout(attemptUnstake, RETRY_INTERVAL_MS)
     }
-  }, RETRY_INTERVAL_MS)
-}
-
-function checkRateLimit(): boolean {
-  if (lastFailedUnstakeAttempt === null) return false
-
-  const timeSinceLastAttempt = Date.now() - lastFailedUnstakeAttempt
-  if (timeSinceLastAttempt < UNSTAKE_RATE_LIMIT_MS) {
-    const remainingMinutes = Math.ceil((UNSTAKE_RATE_LIMIT_MS - timeSinceLastAttempt) / 60000)
-    console.error(
-      `Please wait ${remainingMinutes} minute${remainingMinutes > 1 ? 's' : ''} before trying to unstake again.`
-    )
-    return true
   }
-  return false
+
+  // Start the process with the initial delay (0 for immediate execution)
+  retryTimeoutId = setTimeout(attemptUnstake, initialDelay)
+
+  // Return a function to cancel the retry process if needed
+  return () => {
+    if (retryTimeoutId) {
+      clearTimeout(retryTimeoutId)
+      retryTimeoutId = null
+    }
+  }
 }
 
-async function unstake(options: { force?: boolean }) {
+async function unstake(options: { force?: boolean, ignoreRateLimit?: boolean }) {
   try {
     const privateKey = await getPrivateKey()
     const provider = new ethers.providers.JsonRpcProvider(rpcServer.url)
     const walletWithProvider = new ethers.Wallet(privateKey, provider)
 
-    startRetryInterval(walletWithProvider, options)
-
-    const txDetails = await createUnstakeTransaction(walletWithProvider, options)
-    await executeUnstakeTransaction(walletWithProvider, txDetails)
+    const runningUnstake = getRunningUnstake()
+    const delay = !options?.ignoreRateLimit && runningUnstake?.timestamp ? RETRY_INTERVAL_MS - (Date.now() - runningUnstake.timestamp) : 0
+    startRetryProcess(walletWithProvider, options, delay > 0 ? delay : 0)
   } catch (error) {
     console.error(error)
     if (lastFailedUnstakeAttempt === null) {
@@ -790,6 +835,7 @@ export function registerNodeCommands(program: Command) {
     .command('unstake')
     .description('Remove staked SHM')
     .option('-f, --force', 'Force unstake in case the node is stuck, will forfeit rewards')
+    .option('--ignoreRateLimit', 'Ignore rate limit to sending unstake txs')
     .action(async (options) => {
       try {
         if (options.force) {

--- a/src/node-commands.ts
+++ b/src/node-commands.ts
@@ -246,6 +246,118 @@ const dashboardPackageJson = JSON.parse(readFileSync(path.join(__dirname, '../..
 // eslint-disable-next-line security/detect-non-literal-fs-filename
 fs.writeFileSync(path.join(__dirname, `../${File.CONFIG}`), JSON.stringify(config, undefined, 2))
 
+let lastFailedUnstakeAttempt: number | null = null
+const UNSTAKE_RATE_LIMIT_MS = 5 * 60 * 1000 // 5 minutes in milliseconds
+const RETRY_INTERVAL_MS = 2 * 60 * 1000 // 2 minutes in milliseconds
+let retryInterval: NodeJS.Timeout | null = null
+
+async function getPrivateKey(): Promise<string> {
+  let privateKey = await getUserInput('Please enter your private key: ')
+  while (privateKey.length !== 64 || !isValidPrivate(Buffer.from(privateKey, 'hex'))) {
+    console.log('Invalid private key entered.')
+    privateKey = await getUserInput('Please enter your private key: ')
+  }
+  return privateKey
+}
+
+async function createUnstakeTransaction(walletWithProvider: ethers.Wallet, options: { force?: boolean }) {
+  const eoaData = await fetchEOADetails(config, walletWithProvider.address)
+  if (!eoaData) {
+    throw new Error("Couldn't unstake (`eoaData` is null)")
+  }
+
+  if (eoaData.operatorAccountInfo?.nominee == null || eoaData.operatorAccountInfo?.stake?.value === '00') {
+    throw new Error('No stake found')
+  }
+
+  const [gasPrice, from, nonce] = await Promise.all([
+    walletWithProvider.getGasPrice(),
+    walletWithProvider.getAddress(),
+    walletWithProvider.getTransactionCount(),
+  ])
+
+  const unstakeData = {
+    isInternalTx: true,
+    internalTXType: 7,
+    nominator: walletWithProvider.address.toLowerCase(),
+    timestamp: Date.now(),
+    nominee: eoaData?.operatorAccountInfo?.nominee,
+    force: options.force ?? false,
+  }
+
+  return {
+    from,
+    to: '0x0000000000000000000000000000000000010000',
+    gasPrice,
+    gasLimit: 30000000,
+    data: ethers.utils.hexlify(ethers.utils.toUtf8Bytes(JSON.stringify(unstakeData))),
+    nonce,
+  }
+}
+
+async function executeUnstakeTransaction(walletWithProvider: ethers.Wallet, txDetails: any) {
+  const { hash, data, wait } = await walletWithProvider.sendTransaction(txDetails)
+  console.log('TX RECEIPT: ', { hash, data })
+  const txConfirmation = await wait()
+  console.log('TX CONFIRMED: ', txConfirmation)
+  return txConfirmation
+}
+
+function startRetryInterval(walletWithProvider: ethers.Wallet, options: { force?: boolean }) {
+  if (retryInterval) return
+
+  retryInterval = setInterval(async () => {
+    try {
+      const txDetails = await createUnstakeTransaction(walletWithProvider, options)
+      console.log('Retrying unstake with data:', txDetails)
+      await executeUnstakeTransaction(walletWithProvider, txDetails)
+
+      if (retryInterval) {
+        clearInterval(retryInterval)
+        retryInterval = null
+      }
+      lastFailedUnstakeAttempt = null
+    } catch (error) {
+      console.error('Retry attempt failed:', error)
+      lastFailedUnstakeAttempt = Date.now()
+    }
+  }, RETRY_INTERVAL_MS)
+}
+
+function checkRateLimit(): boolean {
+  if (lastFailedUnstakeAttempt === null) return false
+
+  const timeSinceLastAttempt = Date.now() - lastFailedUnstakeAttempt
+  if (timeSinceLastAttempt < UNSTAKE_RATE_LIMIT_MS) {
+    const remainingMinutes = Math.ceil((UNSTAKE_RATE_LIMIT_MS - timeSinceLastAttempt) / 60000)
+    console.error(
+      `Please wait ${remainingMinutes} minute${remainingMinutes > 1 ? 's' : ''} before trying to unstake again.`
+    )
+    return true
+  }
+  return false
+}
+
+async function unstake(options: { force?: boolean }) {
+  try {
+    const privateKey = await getPrivateKey()
+    const provider = new ethers.providers.JsonRpcProvider(rpcServer.url)
+    const walletWithProvider = new ethers.Wallet(privateKey, provider)
+
+    if (checkRateLimit()) {
+      console.log('Will automatically retry the transaction every 2 minutes...')
+      startRetryInterval(walletWithProvider, options)
+      return
+    }
+
+    const txDetails = await createUnstakeTransaction(walletWithProvider, options)
+    await executeUnstakeTransaction(walletWithProvider, txDetails)
+  } catch (error) {
+    console.error(error)
+    lastFailedUnstakeAttempt = Date.now()
+  }
+}
+
 export function registerNodeCommands(program: Command) {
   program
     .command('status')
@@ -676,66 +788,6 @@ export function registerNodeCommands(program: Command) {
       }
     })
 
-  async function unstake(options: { force: boolean }) {
-    // Take input from user for PRIVATE KEY
-    let privateKey = await getUserInput('Please enter your private key: ')
-    while (privateKey.length !== 64 || !isValidPrivate(Buffer.from(privateKey, 'hex'))) {
-      console.log('Invalid private key entered.')
-      privateKey = await getUserInput('Please enter your private key: ')
-    }
-
-    try {
-      const provider = new ethers.providers.JsonRpcProvider(rpcServer.url)
-
-      const walletWithProvider = new ethers.Wallet(privateKey, provider)
-
-      const eoaData = await fetchEOADetails(config, walletWithProvider.address)
-      if (!eoaData) {
-        console.error("Couldn't unstake (`eoaData` is null)")
-        return
-      }
-
-      if (eoaData.operatorAccountInfo?.nominee == null || eoaData.operatorAccountInfo?.stake?.value === '00') {
-        console.error('No stake found')
-        return
-      }
-
-      const [gasPrice, from, nonce] = await Promise.all([
-        walletWithProvider.getGasPrice(),
-        walletWithProvider.getAddress(),
-        walletWithProvider.getTransactionCount(),
-      ])
-
-      const unstakeData = {
-        isInternalTx: true,
-        internalTXType: 7,
-        nominator: walletWithProvider.address.toLowerCase(),
-        timestamp: Date.now(),
-        nominee: eoaData?.operatorAccountInfo?.nominee,
-        force: options.force ?? false,
-      }
-      console.log(unstakeData)
-
-      const txDetails = {
-        from,
-        to: '0x0000000000000000000000000000000000010000',
-        gasPrice,
-        gasLimit: 30000000,
-        data: ethers.utils.hexlify(ethers.utils.toUtf8Bytes(JSON.stringify(unstakeData))),
-        nonce,
-      }
-      console.log(txDetails)
-
-      const { hash, data, wait } = await walletWithProvider.sendTransaction(txDetails)
-
-      console.log('TX RECEIPT: ', { hash, data })
-      const txConfirmation = await wait()
-      console.log('TX CONFRIMED: ', txConfirmation)
-    } catch (error) {
-      console.error(error)
-    }
-  }
-
   program
     .command('unstake')
     .description('Remove staked SHM')
@@ -758,15 +810,15 @@ export function registerNodeCommands(program: Command) {
           } catch (error: unknown) {
             // Error while fetching nodeInfo - presuming node is not active
           }
-          const nodeStatus = nodeInfo?.status
-          if (
-            nodeStatus === 'initializing' ||
-            nodeStatus === 'standby' ||
-            nodeStatus === 'syncing' ||
-            nodeStatus === 'active'
-          ) {
-            throw 'Please stop your node before unstaking.'
-          }
+          // const nodeStatus = nodeInfo?.status
+          // if (
+          //   nodeStatus === 'initializing' ||
+          //   nodeStatus === 'standby' ||
+          //   nodeStatus === 'syncing' ||
+          //   nodeStatus === 'active'
+          // ) {
+          //   throw 'Please stop your node before unstaking.'
+          // }
         }
 
         await unstake(options)

--- a/src/node-commands.ts
+++ b/src/node-commands.ts
@@ -854,15 +854,15 @@ export function registerNodeCommands(program: Command) {
           } catch (error: unknown) {
             // Error while fetching nodeInfo - presuming node is not active
           }
-          // const nodeStatus = nodeInfo?.status
-          // if (
-          //   nodeStatus === 'initializing' ||
-          //   nodeStatus === 'standby' ||
-          //   nodeStatus === 'syncing' ||
-          //   nodeStatus === 'active'
-          // ) {
-          //   throw 'Please stop your node before unstaking.'
-          // }
+          const nodeStatus = nodeInfo?.status
+          if (
+            nodeStatus === 'initializing' ||
+            nodeStatus === 'standby' ||
+            nodeStatus === 'syncing' ||
+            nodeStatus === 'active'
+          ) {
+            throw 'Please stop your node before unstaking.'
+          }
         }
 
         await unstake(options)

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -11,6 +11,7 @@ export enum File {
   START_SUMMARY = 'start-summary.json',
   NODE_PROGRESS = 'node-progress.json',
   ENVIRONMENT_CONFIG = 'environment.config.js',
+  UNSTAKE_REQUEST = 'unstake-request.json',
 }
 
 export * from './fetch-network-data'


### PR DESCRIPTION
### **PR Type**
enhancement


___

### **Description**
- Introduced automatic retry mechanism for unstake transactions.

- Added delay and rate limiting for unstake attempts.

- Implemented file-based tracking for unstake processes.

- Enhanced user input validation for private keys.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>node-commands.ts</strong><dd><code>Implement retry and rate limiting for unstake</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/node-commands.ts

<li>Added automatic retry mechanism for unstake transactions.<br> <li> Implemented delay and rate limiting for unstake attempts.<br> <li> Introduced file-based tracking for unstake processes.<br> <li> Enhanced user input validation for private keys.


</details>


  </td>
  <td><a href="https://github.com/shardeum/shardeum-validator-cli/pull/54/files#diff-16e6e49d3bbc5c66140d8f145f7990ca668256de32ecb0a0da81774b14d0b889">+156/-60</a></td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>index.ts</strong><dd><code>Add `UNSTAKE_REQUEST` to File enum</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/utils/index.ts

- Added `UNSTAKE_REQUEST` to `File` enum.


</details>


  </td>
  <td><a href="https://github.com/shardeum/shardeum-validator-cli/pull/54/files#diff-6147e3c1761df71fd40952dbcbac388a45f80b8c318f367ef41048351a2c0c99">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>