### PR TITLE
SAHRD-2196: prevent 404 when nominee is not set

### DIFF
--- a/src/utils/fetch-network-data.ts
+++ b/src/utils/fetch-network-data.ts
@@ -311,6 +311,14 @@ export async function fetchUnstakeableDetails(config: networkConfigType, nominee
 }
 
 export async function fetchStakeableDetails(config: networkConfigType, nominee: string) {
+  if (nominee === '') {
+    return {
+      restakeAllowed: false,
+      reason: 'No nominee provided',
+      remainingTime: 0,
+    }
+  }
+  
   const stakeable = await fetchDataFromNetwork<{
     stakeAllowed: {
       restakeAllowed: boolean


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Prevent 404 error when nominee is not set.

- Add early return for empty nominee in `fetchStakeableDetails`.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>fetch-network-data.ts</strong><dd><code>Handle empty nominee in `fetchStakeableDetails` function</code>&nbsp; </dd></summary>
<hr>

src/utils/fetch-network-data.ts

<li>Added check for empty nominee in <code>fetchStakeableDetails</code>.<br> <li> Return default response when nominee is not provided.


</details>


  </td>
  <td><a href="https://github.com/shardeum/shardeum-validator-cli/pull/58/files#diff-da3173435eaf9d426e15c1a207703412729be0dcaf0314b8d08841f5a42898fe">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>