### PR TITLE
SHARD-2303: Rotate node to query and add robust query for stake data

### DIFF
--- a/src/node-commands.ts
+++ b/src/node-commands.ts
@@ -366,7 +366,6 @@ async function executeUnstakeTransaction(walletWithProvider: ethers.Wallet, txDe
     } as any
   } else {
     console.log('Transaction sent (hash: ' + hash + ') but confirmation is taking longer than 20 seconds.')
-    console.log('The transaction may still complete successfully. Check your wallet or explorer in a few minutes.')
     return {
       transactionHash: hash,
       status: 'pending',

--- a/src/node-commands.ts
+++ b/src/node-commands.ts
@@ -442,7 +442,6 @@ async function unstake(options: { force?: boolean; ignoreRateLimit?: boolean }) 
       throw new Error('Unstake transaction failed. Try again later or use --ignoreRateLimit option.')
     }
   } catch (error) {
-    console.error(error)
     if (lastFailedUnstakeAttempt === null) {
       lastFailedUnstakeAttempt = Date.now()
     }

--- a/src/node-commands.ts
+++ b/src/node-commands.ts
@@ -333,9 +333,42 @@ async function executeUnstakeTransaction(walletWithProvider: ethers.Wallet, txDe
   const { hash, data, wait } = await walletWithProvider.sendTransaction(txDetails)
   addUnstakeToFile(Date.now(), hash)
   console.log('TX RECEIPT: ', { hash, data })
-  const txConfirmation = await wait()
+
   console.log('TX CONFIRMED: ', txConfirmation)
-  return txConfirmation
+  const timeoutPromise = new Promise<'timeout'>((resolve) => {
+    setTimeout(() => {
+      resolve('timeout')
+    }, 20000) // 20 seconds timeout
+  })
+
+  type ConfirmedResult = {
+    type: 'confirmed'
+    receipt: ethers.providers.TransactionReceipt
+  }
+
+  type TimeoutResult = {
+    type: 'timeout'
+    hash: string
+  }
+
+  type RaceResult = ConfirmedResult | TimeoutResult
+
+  const result = await Promise.race<RaceResult>([
+    wait().then((receipt) => ({ type: 'confirmed', receipt } as ConfirmedResult)),
+    timeoutPromise.then(() => ({ type: 'timeout', hash } as TimeoutResult)),
+  ])
+
+  if (result.type === 'confirmed') {
+    console.log('TX CONFIRMED: ', result.receipt)
+    return result.receipt
+  } else {
+    console.log('Transaction sent (hash: ' + hash + ') but confirmation is taking longer than 20 seconds.')
+    console.log('The transaction may still complete successfully. Check your wallet or explorer in a few minutes.')
+    return {
+      transactionHash: hash,
+      status: 'pending',
+    } as any
+  }
 }
 
 async function unstake(options: { force?: boolean; ignoreRateLimit?: boolean }) {
@@ -848,12 +881,43 @@ export function registerNodeCommands(program: Command) {
         }
 
         const { hash, data, wait } = await walletWithProvider.sendTransaction(txDetails)
-
         console.log('TX RECEIPT: ', { hash, data })
-        const txConfirmation = await wait()
-        console.log('TX CONFRIMED: ', txConfirmation)
+
+        const timeoutPromise = new Promise<'timeout'>((resolve) => {
+          setTimeout(() => {
+            resolve('timeout')
+          }, 20000) // 20 seconds timeout
+        })
+
+        type ConfirmedResult = {
+          type: 'confirmed'
+          receipt: ethers.providers.TransactionReceipt
+        }
+
+        type TimeoutResult = {
+          type: 'timeout'
+          hash: string
+        }
+
+        type RaceResult = ConfirmedResult | TimeoutResult
+
+        const result = await Promise.race<RaceResult>([
+          wait().then((receipt) => ({ type: 'confirmed', receipt } as ConfirmedResult)),
+          timeoutPromise.then(() => ({ type: 'timeout', hash } as TimeoutResult)),
+        ])
+
+        if (result.type === 'confirmed') {
+          console.log('TX CONFIRMED: ', result.receipt)
+          console.log('Stake successful!')
+        } else {
+          console.log('Transaction sent (hash: ' + hash + ') but confirmation is taking longer than 20 seconds.')
+          console.log(
+            'The transaction may still complete successfully. Check your wallet or explorer in a few minutes.'
+          )
+          console.log('Stake operation is still pending. Your SHM should stake within a few minutes.')
+        }
       } catch (error) {
-        console.error(error)
+        console.error('Failed to stake:', error)
       }
     })
 
@@ -892,7 +956,16 @@ export function registerNodeCommands(program: Command) {
           }
         }
 
-        await unstake(options)
+        const result = await unstake(options)
+
+        if (result) {
+          console.log('Unstake completed successfully.')
+        } else {
+          console.log(
+            'Unstake operation is still pending. Please try again if your SHM does not unstake after 2 minutes.'
+          )
+        }
+
         process.exit(0)
       } catch (error) {
         console.error(error)

--- a/src/node-commands.ts
+++ b/src/node-commands.ts
@@ -334,7 +334,6 @@ async function executeUnstakeTransaction(walletWithProvider: ethers.Wallet, txDe
   addUnstakeToFile(Date.now(), hash)
   console.log('TX RECEIPT: ', { hash, data })
 
-  console.log('TX CONFIRMED: ', txConfirmation)
   const timeoutPromise = new Promise<'timeout'>((resolve) => {
     setTimeout(() => {
       resolve('timeout')

--- a/src/node-commands.ts
+++ b/src/node-commands.ts
@@ -359,7 +359,11 @@ async function executeUnstakeTransaction(walletWithProvider: ethers.Wallet, txDe
 
   if (result.type === 'confirmed') {
     console.log('TX CONFIRMED: ', result.receipt)
-    return result.receipt
+    return {
+      transactionHash: result.receipt.transactionHash,
+      status: 'confirmed',
+      receipt: result.receipt,
+    } as any
   } else {
     console.log('Transaction sent (hash: ' + hash + ') but confirmation is taking longer than 20 seconds.')
     console.log('The transaction may still complete successfully. Check your wallet or explorer in a few minutes.')
@@ -422,10 +426,17 @@ async function unstake(options: { force?: boolean; ignoreRateLimit?: boolean }) 
     console.log('Sending unstake transaction...')
     try {
       const confirmation = await executeUnstakeTransaction(walletWithProvider, txDetails)
-      console.log('Unstake successful!', confirmation.transactionHash)
-      // Clean up unstake file
-      removeUnstakeFile()
-      return true
+
+      if (confirmation.status === 'confirmed') {
+        console.log('Unstake successful!', confirmation.transactionHash)
+        // Clean up unstake file
+        removeUnstakeFile()
+        return { success: true, pending: false }
+      } else if (confirmation.status === 'pending') {
+        return { success: true, pending: true }
+      } else {
+        return { success: true, pending: true }
+      }
     } catch (error) {
       console.error('Failed to execute unstake transaction:', error)
       throw new Error('Unstake transaction failed. Try again later or use --ignoreRateLimit option.')
@@ -435,7 +446,7 @@ async function unstake(options: { force?: boolean; ignoreRateLimit?: boolean }) 
     if (lastFailedUnstakeAttempt === null) {
       lastFailedUnstakeAttempt = Date.now()
     }
-    return false
+    return { success: false, error }
   }
 }
 
@@ -801,57 +812,55 @@ export function registerNodeCommands(program: Command) {
     .argument('<value>', 'The amount of SHM to stake')
     .description('Stake the set amount of SHM at the stake address. Rewards will be sent to set reward address.')
     .action(async (stakeValue) => {
-      // Fetch the public key from secrets.json
-      // eslint-disable-next-line security/detect-non-literal-fs-filename
-      if (!fs.existsSync(path.join(__dirname, `../${File.SECRETS}`))) {
-        console.error('Please start the node once before staking')
-        return
-      }
-
-      const secrets = JSON.parse(
-        // eslint-disable-next-line security/detect-non-literal-fs-filename
-        fs.readFileSync(path.join(__dirname, `../${File.SECRETS}`)).toString()
-      )
-
-      if (secrets.publicKey == null) {
-        console.error('Unable to find public key in secrets.json')
-        return
-      }
-
-      // Check if staking is allowed
-      const stakeable = await fetchStakeableDetails(config, secrets.publicKey)
-      if (!stakeable?.restakeAllowed && stakeable?.remainingTime != null) {
-        const minutes = Math.floor(stakeable.remainingTime / 60000)
-        const seconds = Math.floor((stakeable.remainingTime % 60000) / 1000)
-        console.error(`Your last stake action was too recent. Please wait ${minutes}m ${seconds}s to stake again.`)
-        return
-      }
-
-      // Take input from user for PRIVATE KEY
-      let privateKey = await getUserInput('Please enter your private key: ')
-      while (privateKey.length !== 64 || !isValidPrivate(Buffer.from(privateKey, 'hex'))) {
-        console.log('Invalid private key entered.')
-        privateKey = await getUserInput('Please enter your private key: ')
-      }
-
-      const provider = new ethers.providers.JsonRpcProvider(rpcServer.url)
-
-      const walletWithProvider = new ethers.Wallet(privateKey, provider)
-
-      const [{ stakeRequired }, eoaData] = await Promise.all([
-        fetchStakeParameters(config),
-        fetchEOADetails(config, walletWithProvider.address),
-      ])
-
-      if (ethers.BigNumber.from(stakeRequired).gt(ethers.utils.parseEther(stakeValue))) {
-        if (eoaData == null) {
-          /*prettier-ignore*/
-          console.error(`Stake amount must be greater than ${ethers.utils.formatEther(stakeRequired)} SHM`);
-          return
-        }
-      }
-
       try {
+        if (!fs.existsSync(path.join(__dirname, `../${File.SECRETS}`))) {
+          console.error('Please start the node once before staking')
+          process.exit(1)
+        }
+
+        const secrets = JSON.parse(
+          // eslint-disable-next-line security/detect-non-literal-fs-filename
+          fs.readFileSync(path.join(__dirname, `../${File.SECRETS}`)).toString()
+        )
+
+        if (secrets.publicKey == null) {
+          console.error('Unable to find public key in secrets.json')
+          process.exit(1)
+        }
+
+        // Check if staking is allowed
+        const stakeable = await fetchStakeableDetails(config, secrets.publicKey)
+        if (!stakeable?.restakeAllowed && stakeable?.remainingTime != null) {
+          const minutes = Math.floor(stakeable.remainingTime / 60000)
+          const seconds = Math.floor((stakeable.remainingTime % 60000) / 1000)
+          console.error(`Your last stake action was too recent. Please wait ${minutes}m ${seconds}s to stake again.`)
+          process.exit(1)
+        }
+
+        // Take input from user for PRIVATE KEY
+        let privateKey = await getUserInput('Please enter your private key: ')
+        while (privateKey.length !== 64 || !isValidPrivate(Buffer.from(privateKey, 'hex'))) {
+          console.log('Invalid private key entered.')
+          privateKey = await getUserInput('Please enter your private key: ')
+        }
+
+        const provider = new ethers.providers.JsonRpcProvider(rpcServer.url)
+
+        const walletWithProvider = new ethers.Wallet(privateKey, provider)
+
+        const [{ stakeRequired }, eoaData] = await Promise.all([
+          fetchStakeParameters(config),
+          fetchEOADetails(config, walletWithProvider.address),
+        ])
+
+        if (ethers.BigNumber.from(stakeRequired).gt(ethers.utils.parseEther(stakeValue))) {
+          if (eoaData == null) {
+            /*prettier-ignore*/
+            console.error(`Stake amount must be greater than ${ethers.utils.formatEther(stakeRequired)} SHM`);
+            process.exit(1)
+          }
+        }
+
         const [gasPrice, from, nonce] = await Promise.all([
           walletWithProvider.getGasPrice(),
           walletWithProvider.getAddress(),
@@ -908,15 +917,18 @@ export function registerNodeCommands(program: Command) {
         if (result.type === 'confirmed') {
           console.log('TX CONFIRMED: ', result.receipt)
           console.log('Stake successful!')
+          process.exit(0)
         } else {
           console.log('Transaction sent (hash: ' + hash + ') but confirmation is taking longer than 20 seconds.')
           console.log(
             'The transaction may still complete successfully. Check your wallet or explorer in a few minutes.'
           )
           console.log('Stake operation is still pending. Your SHM should stake within a few minutes.')
+          process.exit(0)
         }
       } catch (error) {
         console.error('Failed to stake:', error)
+        process.exit(1)
       }
     })
 
@@ -934,7 +946,7 @@ export function registerNodeCommands(program: Command) {
           )
 
           if (answer.toLowerCase() !== 'y') {
-            return
+            process.exit(0)
           }
         } else {
           let nodeInfo
@@ -957,12 +969,17 @@ export function registerNodeCommands(program: Command) {
 
         const result = await unstake(options)
 
-        if (result) {
-          console.log('Unstake completed successfully.')
+        if (result?.success) {
+          if (result.pending) {
+            console.log(
+              'Unstake operation is still pending. Please try again if your SHM does not unstake after 2 minutes.'
+            )
+          } else {
+            console.log('Unstake completed successfully.')
+          }
         } else {
-          console.log(
-            'Unstake operation is still pending. Please try again if your SHM does not unstake after 2 minutes.'
-          )
+          console.error(result?.error || 'Unstake operation failed with unknown error')
+          process.exit(1)
         }
 
         process.exit(0)

--- a/src/node-commands.ts
+++ b/src/node-commands.ts
@@ -919,9 +919,6 @@ export function registerNodeCommands(program: Command) {
           process.exit(0)
         } else {
           console.log('Transaction sent (hash: ' + hash + ') but confirmation is taking longer than 20 seconds.')
-          console.log(
-            'The transaction may still complete successfully. Check your wallet or explorer in a few minutes.'
-          )
           console.log('Stake operation is still pending. Your SHM should stake within a few minutes.')
           process.exit(0)
         }

--- a/src/utils/fetch-network-data.ts
+++ b/src/utils/fetch-network-data.ts
@@ -320,7 +320,6 @@ export async function fetchUnstakeableDetails(config: networkConfigType, nominee
 
     return unstakable.value?.stakeUnlocked
   } catch (error) {
-
     return fetchDataFromNetwork<{
       stakeUnlocked: {
         unlocked: boolean
@@ -361,7 +360,6 @@ export async function fetchStakeableDetails(config: networkConfigType, nominee: 
 
     return stakeable.value?.stakeAllowed
   } catch (error) {
-
     try {
       const stakeable = await fetchDataFromNetwork<{
         stakeAllowed: {

--- a/src/utils/fetch-network-data.ts
+++ b/src/utils/fetch-network-data.ts
@@ -7,6 +7,7 @@ import fs from 'fs'
 import path from 'path'
 import tcache from './tcache'
 import { File } from '../utils'
+import { fetchActiveNodes, makeRobustQueryCall } from './robust-query'
 
 export const cache = new tcache()
 export const networkAccount = '1000000000000000000000000000000000000000000000000000000000000001'
@@ -298,16 +299,38 @@ export async function fetchEOADetails(config: networkConfigType, eoaAddress: str
 
   return eoaParams?.account
 }
-export async function fetchUnstakeableDetails(config: networkConfigType, nominee: string, nominator: string) {
-  const unstakable = await fetchDataFromNetwork<{
-    stakeUnlocked: {
-      unlocked: boolean
-      reason: string
-      remainingTime: number
-    }
-  }>(config, `/canUnstake/${nominee}/${nominator}`, (data) => data?.stakeUnlocked == null)
 
-  return unstakable?.stakeUnlocked
+export async function fetchUnstakeableDetails(config: networkConfigType, nominee: string, nominator: string) {
+  try {
+    // Get active nodes
+    const activeNodes = await fetchActiveNodes(config)
+
+    if (activeNodes.length === 0) {
+      throw new Error('No active nodes available')
+    }
+
+    // Make robust query call
+    const unstakable = await makeRobustQueryCall<{
+      stakeUnlocked: {
+        unlocked: boolean
+        reason: string
+        remainingTime: number
+      }
+    }>(activeNodes, `/canUnstake/${nominee}/${nominator}`)
+
+    return unstakable.value?.stakeUnlocked
+  } catch (error) {
+
+    return fetchDataFromNetwork<{
+      stakeUnlocked: {
+        unlocked: boolean
+        reason: string
+        remainingTime: number
+      }
+    }>(config, `/canUnstake/${nominee}/${nominator}`, (data) => data?.stakeUnlocked == null).then(
+      (response) => response?.stakeUnlocked
+    )
+  }
 }
 
 export async function fetchStakeableDetails(config: networkConfigType, nominee: string) {
@@ -318,12 +341,43 @@ export async function fetchStakeableDetails(config: networkConfigType, nominee: 
       remainingTime: 0,
     }
   }
-  
-  const stakeable = await fetchDataFromNetwork<{
-    stakeAllowed: {
-      restakeAllowed: boolean
-      reason: string
-      remainingTime: number
+
+  try {
+    // Get active nodes
+    const activeNodes = await fetchActiveNodes(config)
+
+    if (activeNodes.length === 0) {
+      throw new Error('No active nodes available')
+    }
+
+    // Make robust query call
+    const stakeable = await makeRobustQueryCall<{
+      stakeAllowed: {
+        restakeAllowed: boolean
+        reason: string
+        remainingTime: number
+      }
+    }>(activeNodes, `/canStake/${nominee}`)
+
+    return stakeable.value?.stakeAllowed
+  } catch (error) {
+
+    try {
+      const stakeable = await fetchDataFromNetwork<{
+        stakeAllowed: {
+          restakeAllowed: boolean
+          reason: string
+          remainingTime: number
+        }
+      }>(config, `/canStake/${nominee}`, (data) => data?.error != 'account not found' && data?.stakeAllowed == null)
+
+      return stakeable?.stakeAllowed
+    } catch (error) {
+      return {
+        restakeAllowed: true,
+        reason: 'Network request failed, allowing stake by default',
+        remainingTime: 0,
+      }
     }
   }>(config, `/canStake/${nominee}`, (data) => data?.error != 'account not found' && data?.stakeAllowed == null)
 

--- a/src/utils/fetch-network-data.ts
+++ b/src/utils/fetch-network-data.ts
@@ -375,9 +375,7 @@ export async function fetchStakeableDetails(config: networkConfigType, nominee: 
         remainingTime: 0,
       }
     }
-  }>(config, `/canStake/${nominee}`, (data) => data?.error != 'account not found' && data?.stakeAllowed == null)
-
-  return stakeable?.stakeAllowed
+  }
 }
 
 export async function fetchValidatorVersions(config: networkConfigType) {

--- a/src/utils/fetch-network-data.ts
+++ b/src/utils/fetch-network-data.ts
@@ -50,9 +50,7 @@ async function fetchDataFromNetwork<T>(
   callback: (response: { [id: string]: string } | null) => boolean
 ): Promise<T | null> {
   let retries = 5
-  if (!readActiveNode()) {
-    await getNewActiveNode(config)
-  }
+  await getNewActiveNode(config)
 
   if (!savedActiveNode) {
     throw new Error('Unable to fetch active node')
@@ -127,7 +125,7 @@ async function fetchDataFromNetwork<T>(
 export async function getNewActiveNode(config: networkConfigType): Promise<void> {
   const randomArchiver =
     config.server.p2p.existingArchivers[Math.floor(Math.random() * config.server.p2p.existingArchivers.length)]
-  const archiverUrl = `http://${randomArchiver.ip}:${randomArchiver.port}/nodelist`
+  const archiverUrl = `http://${randomArchiver.ip}:${randomArchiver.port}/nodelist?activeOnly=true`
   const nodeList = await axios
     .get(archiverUrl, { timeout: 2000 })
     .then((res) => res.data)

--- a/src/utils/robust-query.ts
+++ b/src/utils/robust-query.ts
@@ -1,0 +1,372 @@
+import axios, { AxiosError } from 'axios'
+import { networkConfigType } from '../config/default-network-config'
+import { isIP } from 'net'
+
+/**
+ * Simple sleep utility
+ */
+export const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms))
+
+/**
+ * A class for tallying responses and determining consensus
+ */
+class Tally<T> {
+  private winCount: number
+  private equalFn: (a: T, b: T) => boolean
+  private items: Array<{
+    value: T
+    count: number
+    nodes: Array<{ ip: string; port: number | string }>
+  }>
+
+  constructor(winCount: number, equalFn: (a: T, b: T) => boolean) {
+    this.winCount = winCount
+    this.equalFn = equalFn
+    this.items = []
+  }
+
+  /**
+   * Add a new item to the tally
+   * @param newItem The item to add
+   * @param node The node that returned this item
+   * @returns The winning item if consensus reached, otherwise null
+   */
+  add(
+    newItem: T,
+    node: { ip: string; port: number | string }
+  ): { value: T; count: number; nodes: Array<{ ip: string; port: number | string }> } | null {
+    if (newItem === null) return null
+
+    // Look for existing items that match
+    for (const item of this.items) {
+      // If the value of the new item is not equal to the current item, we continue searching
+      if (!this.equalFn(newItem, item.value)) continue
+
+      // If the new item is equal to the current item in the list,
+      // we increment the current item's counter and add the current node to the list
+      item.count++
+      item.nodes.push(node)
+
+      // Check if we've reached consensus
+      if (item.count >= this.winCount) {
+        return item
+      }
+
+      // No winner yet
+      return null
+    }
+
+    // If we made it through the entire items list without finding a match,
+    // We create a new item and set the count to 1
+    const newTallyItem = { value: newItem, count: 1, nodes: [node] }
+    this.items.push(newTallyItem)
+
+    // If the winCount is 1, return the item we just created
+    if (this.winCount === 1) return newTallyItem
+    else return null
+  }
+
+  /**
+   * Get the highest count of any item
+   */
+  getHighestCount(): number {
+    if (!this.items.length) return 0
+
+    let highestCount = 0
+    for (const item of this.items) {
+      if (item.count > highestCount) {
+        highestCount = item.count
+      }
+    }
+
+    return highestCount
+  }
+
+  /**
+   * Get the item with the highest count
+   */
+  getHighestCountItem(): { value: T; count: number; nodes: Array<{ ip: string; port: number | string }> } | null {
+    if (!this.items.length) return null
+
+    let highestCount = 0
+    let highestIndex = 0
+    let i = 0
+    for (const item of this.items) {
+      if (item.count > highestCount) {
+        highestCount = item.count
+        highestIndex = i
+      }
+      i += 1
+    }
+    return this.items[highestIndex]
+  }
+}
+
+/**
+ * Execute multiple promises and handle errors individually
+ */
+async function robustPromiseAll<T>(promises: Promise<T>[]): Promise<[T[], Error[]]> {
+  const results: T[] = []
+  const errors: Error[] = []
+
+  await Promise.all(
+    promises.map(async (promise) => {
+      try {
+        const result = await promise
+        results.push(result)
+      } catch (error) {
+        errors.push(error instanceof Error ? error : new Error(String(error)))
+      }
+    })
+  )
+
+  return [results, errors]
+}
+
+/**
+ * Function to retry an operation with backoff
+ */
+export async function attempt<T>(
+  fn: () => Promise<T>,
+  options: {
+    maxRetries: number
+    logPrefix: string
+  }
+): Promise<T> {
+  let lastError: Error | null = null
+  for (let attempt = 0; attempt <= options.maxRetries; attempt++) {
+    try {
+      return await fn()
+    } catch (e) {
+      lastError = e instanceof Error ? e : new Error(String(e))
+      console.error(
+        `${options.logPrefix}: attempt ${attempt + 1}/${options.maxRetries + 1} failed: ${lastError.message}`
+      )
+
+      if (attempt < options.maxRetries) {
+        // Exponential backoff with jitter
+        const delay = Math.min(100 * Math.pow(2, attempt), 1000) + Math.random() * 100
+        await sleep(delay)
+      }
+    }
+  }
+
+  throw lastError || new Error(`${options.logPrefix}: all attempts failed`)
+}
+
+/**
+ * Makes a robust query to multiple nodes and ensures consensus on the response
+ * @param nodes Array of nodes to query
+ * @param queryFn Function that takes a node and returns a promise of the query result
+ * @param redundancy Number of matching responses required for consensus
+ * @param equalityFn Function to compare responses (defaults to deep equality)
+ * @returns The consensus result or best available result
+ */
+export async function robustQuery<T>(
+  nodes: Array<{ ip: string; port: number | string }>,
+  queryFn: (node: { ip: string; port: number | string }) => Promise<T>,
+  redundancy = 3,
+  equalityFn = (a: T, b: T): boolean => {
+    try {
+      return JSON.stringify(a) === JSON.stringify(b)
+    } catch (e) {
+      return a === b
+    }
+  },
+  shuffleNodes = true,
+  delayTimeInMS = 0
+): Promise<{ value: T; count: number; nodes: Array<{ ip: string; port: number | string }> } | null> {
+  if (nodes.length === 0) {
+    throw new Error('No nodes provided for robust query')
+  }
+
+  // Adjust redundancy if needed
+  if (redundancy < 1) redundancy = 3
+  if (redundancy > nodes.length) redundancy = nodes.length
+
+  const responses = new Tally<T>(redundancy, equalityFn)
+  let errors = 0
+
+  // Shuffle nodes if requested
+  const availableNodes = [...nodes]
+  if (shuffleNodes) {
+    availableNodes.sort(() => 0.5 - Math.random())
+  }
+
+  const queryNodes = async (
+    nodeBatch: Array<{ ip: string; port: number | string }>
+  ): Promise<{ value: T; count: number; nodes: Array<{ ip: string; port: number | string }> } | null> => {
+    // Wrap the query so that we know which node it's coming from
+    const wrappedQuery = async (node: { ip: string; port: number | string }) => {
+      const response = await queryFn(node)
+      return { response, node }
+    }
+
+    // Create a promise for each node in the batch
+    const queries = nodeBatch.map((node) => wrappedQuery(node))
+    const [results, errs] = await robustPromiseAll(queries)
+
+    let finalResult = null
+    for (const result of results) {
+      finalResult = responses.add(result.response, result.node)
+      if (finalResult) break
+    }
+
+    errors += errs.length
+    return finalResult
+  }
+
+  let finalResult = null
+  let tries = 0
+  while (!finalResult) {
+    tries += 1
+    const toQuery = redundancy - responses.getHighestCount()
+    if (availableNodes.length < toQuery) {
+      console.error('Robust query: stopping since we ran out of nodes to query.')
+      break
+    }
+
+    if (delayTimeInMS > 0 && Math.ceil(nodes.length / 2) >= availableNodes.length) {
+      await sleep(delayTimeInMS)
+    }
+
+    const nodesToQuery = availableNodes.splice(0, toQuery)
+    finalResult = await queryNodes(nodesToQuery)
+
+    if (tries >= 20) {
+      console.error('Robust query: stopping after 20 tries.')
+      break
+    }
+  }
+
+  if (finalResult) {
+    return finalResult
+  } else {
+    console.error(
+      `Robust query: Could not get ${redundancy} redundant responses from ${nodes.length} nodes. Encountered ${errors} query errors.`
+    )
+    return responses.getHighestCountItem()
+  }
+}
+
+/**
+ * Get active nodes from multiple archivers
+ * @param config Network configuration
+ * @returns Array of active nodes
+ */
+export async function fetchActiveNodes(
+  config: networkConfigType
+): Promise<Array<{ ip: string; port: number | string; id?: string; publicKey?: string }>> {
+  // Filter out archivers with invalid IPs
+  const validArchivers = config.server.p2p.existingArchivers.filter((archiver) => isIP(archiver.ip))
+
+  if (validArchivers.length === 0) {
+    throw new Error('No valid archivers available')
+  }
+
+  // Create query function for fetching active nodes
+  const queryFn = async (archiver: { ip: string; port: number | string }) => {
+    try {
+      const response = await axios.get(`http://${archiver.ip}:${archiver.port}/nodelist?activeOnly=true`, {
+        timeout: 2000,
+      })
+      if (response.data?.nodeList && Array.isArray(response.data.nodeList)) {
+        return response.data.nodeList
+      }
+      return []
+    } catch (error) {
+      throw error instanceof Error ? error : new Error(String(error))
+    }
+  }
+
+  // Use robust query to get consensus on active nodes
+  const redundancy = Math.min(validArchivers.length, 2)
+  try {
+    const result = await robustQuery(validArchivers, queryFn, redundancy)
+
+    if (result && Array.isArray(result.value)) {
+      return result.value
+    }
+
+    // Fallback to direct query if robust query fails
+    for (const archiver of validArchivers) {
+      try {
+        const nodes = await queryFn(archiver)
+        if (nodes.length > 0) {
+          return nodes
+        }
+      } catch (error) {
+        continue
+      }
+    }
+  } catch (error) {
+    console.error(`Error in fetchActiveNodes: ${error instanceof Error ? error.message : String(error)}`)
+  }
+
+  return []
+}
+
+/**
+ * Makes a robust query call to multiple nodes for a specific endpoint
+ * @param nodes Array of nodes to query
+ * @param endpointName API endpoint to call
+ * @param queryParams Optional query parameters
+ * @returns Object containing the consensus result and winning nodes
+ */
+export async function makeRobustQueryCall<T>(
+  nodes: Array<{ ip: string; port: number | string }>,
+  endpointName: string,
+  queryParams: Record<string, string> = {}
+): Promise<{ winningNodes: Array<{ ip: string; port: number | string }>; value: T }> {
+  if (nodes.length === 0) {
+    throw new Error('No nodes provided for robust query')
+  }
+
+  // Create the query function that will be passed to robustQuery
+  const queryFn = async (node: { ip: string; port: number | string }): Promise<T> => {
+    try {
+      // Build query string
+      const queryStr = Object.entries(queryParams)
+        .map(([key, value]) => `${encodeURIComponent(key)}=${encodeURIComponent(value)}`)
+        .join('&')
+
+      const queryPart = queryStr ? `?${queryStr}` : ''
+      const url = `http://${node.ip}:${node.port}${endpointName}${queryPart}`
+
+      const response = await axios.get(url, { timeout: 3000 })
+      return response.data
+    } catch (error) {
+      if (error instanceof AxiosError && error.response) {
+        // If the API returns a valid response with an error status code, we still return the data
+        return error.response.data as T
+      }
+      throw error
+    }
+  }
+
+  const logPrefix = `robust-query-${endpointName}`
+
+  try {
+    const redundancy = Math.min(Math.max(2, Math.floor(nodes.length / 2)), nodes.length)
+
+    const robustResult = await attempt(() => robustQuery(nodes, queryFn, redundancy), { maxRetries: 3, logPrefix })
+
+    if (!robustResult || robustResult.count < Math.min(redundancy, nodes.length)) {
+      throw new Error(
+        `Result of ${endpointName} wasn't robust enough (count: ${robustResult?.count}, needed: ${Math.min(
+          redundancy,
+          nodes.length
+        )})`
+      )
+    }
+
+    return {
+      winningNodes: robustResult.nodes,
+      value: robustResult.value,
+    }
+  } catch (error) {
+    throw new Error(
+      `Robust query failed for ${endpointName}: ${error instanceof Error ? error.message : String(error)}`
+    )
+  }
+}

--- a/src/utils/robust-query.ts
+++ b/src/utils/robust-query.ts
@@ -323,12 +323,55 @@ export async function makeRobustQueryCall<T>(
     }
   }
 
+  // Create a custom equality function that ignores remainingTime for stake/unstake endpoints
+  const customEqualityFn = (a: T, b: T): boolean => {
+    // For stake/unstake endpoints, ignore remainingTime when comparing responses
+    if (endpointName.includes('/canStake/') || endpointName.includes('/canUnstake/')) {
+      try {
+        // Create deep copies without remainingTime for comparison
+        const aCopy = JSON.parse(JSON.stringify(a))
+        const bCopy = JSON.parse(JSON.stringify(b))
+
+        // Remove remainingTime from stakeAllowed
+        if (aCopy?.stakeAllowed?.remainingTime !== undefined) {
+          delete aCopy.stakeAllowed.remainingTime
+        }
+        if (bCopy?.stakeAllowed?.remainingTime !== undefined) {
+          delete bCopy.stakeAllowed.remainingTime
+        }
+
+        // Remove remainingTime from stakeUnlocked
+        if (aCopy?.stakeUnlocked?.remainingTime !== undefined) {
+          delete aCopy.stakeUnlocked.remainingTime
+        }
+        if (bCopy?.stakeUnlocked?.remainingTime !== undefined) {
+          delete bCopy.stakeUnlocked.remainingTime
+        }
+
+        return JSON.stringify(aCopy) === JSON.stringify(bCopy)
+      } catch (e) {
+        // If JSON parsing fails, fall back to direct comparison
+        return JSON.stringify(a) === JSON.stringify(b)
+      }
+    }
+
+    // For other endpoints, use default comparison
+    try {
+      return JSON.stringify(a) === JSON.stringify(b)
+    } catch (e) {
+      return a === b
+    }
+  }
+
   const logPrefix = `robust-query-${endpointName}`
 
   try {
     const redundancy = Math.min(Math.max(2, Math.floor(nodes.length / 2)), nodes.length)
 
-    const robustResult = await attempt(() => robustQuery(nodes, queryFn, redundancy), { maxRetries: 3, logPrefix })
+    const robustResult = await attempt(() => robustQuery(nodes, queryFn, redundancy, customEqualityFn), {
+      maxRetries: 3,
+      logPrefix,
+    })
 
     if (!robustResult || robustResult.count < Math.min(redundancy, nodes.length)) {
       throw new Error(

--- a/src/utils/robust-query.ts
+++ b/src/utils/robust-query.ts
@@ -264,45 +264,24 @@ export async function fetchActiveNodes(
     throw new Error('No valid archivers available')
   }
 
-  // Create query function for fetching active nodes
-  const queryFn = async (archiver: { ip: string; port: number | string }) => {
+  // Try to fetch nodes from each archiver
+  for (const archiver of validArchivers) {
     try {
       const response = await axios.get(`http://${archiver.ip}:${archiver.port}/nodelist?activeOnly=true`, {
         timeout: 2000,
       })
-      if (response.data?.nodeList && Array.isArray(response.data.nodeList)) {
+
+      if (response.data?.nodeList && Array.isArray(response.data.nodeList) && response.data.nodeList.length > 0) {
         return response.data.nodeList
       }
-      return []
     } catch (error) {
-      throw error instanceof Error ? error : new Error(String(error))
+      // Continue to the next archiver if this one fails
+      console.error(`Failed to fetch nodes from archiver ${archiver.ip}:${archiver.port}`)
     }
   }
 
-  // Use robust query to get consensus on active nodes
-  const redundancy = Math.min(validArchivers.length, 2)
-  try {
-    const result = await robustQuery(validArchivers, queryFn, redundancy)
-
-    if (result && Array.isArray(result.value)) {
-      return result.value
-    }
-
-    // Fallback to direct query if robust query fails
-    for (const archiver of validArchivers) {
-      try {
-        const nodes = await queryFn(archiver)
-        if (nodes.length > 0) {
-          return nodes
-        }
-      } catch (error) {
-        continue
-      }
-    }
-  } catch (error) {
-    console.error(`Error in fetchActiveNodes: ${error instanceof Error ? error.message : String(error)}`)
-  }
-
+  // If we couldn't get a list from any archiver
+  console.error('Could not fetch active nodes from any archiver')
   return []
 }
 


### PR DESCRIPTION
### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Added robust querying for stake and unstake eligibility endpoints.

- Introduced 20-second timeout for stake and unstake CLI commands.

- Improved error handling and user feedback in stake/unstake flows.

- Refactored node selection and consensus logic for network queries.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>node-commands.ts</strong><dd><code>Add CLI timeouts and robust error handling for stake/unstake</code></dd></summary>
<hr>

src/node-commands.ts

<li>Added 20-second timeout for stake and unstake transaction <br>confirmations.<br> <li> Improved error handling and user messaging in stake/unstake commands.<br> <li> Updated CLI flows to handle pending transactions and process exits.<br> <li> Refactored stake/unstake logic to use new robust querying and <br>consensus.


</details>


  </td>
  <td><a href="https://github.com/shardeum/shardeum-validator-cli/pull/65/files#diff-16e6e49d3bbc5c66140d8f145f7990ca668256de32ecb0a0da81774b14d0b889">+140/-56</a></td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>fetch-network-data.ts</strong><dd><code>Use robust consensus queries for network data fetching</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/utils/fetch-network-data.ts

<li>Integrated robust querying for stakeable and unstakeable checks.<br> <li> Updated node list fetching to use activeOnly filter.<br> <li> Improved fallback and error handling for network queries.<br> <li> Refactored to always get a new active node for each request.


</details>


  </td>
  <td><a href="https://github.com/shardeum/shardeum-validator-cli/pull/65/files#diff-da3173435eaf9d426e15c1a207703412729be0dcaf0314b8d08841f5a42898fe">+67/-17</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>robust-query.ts</strong><dd><code>Add robust query utility for consensus-based network calls</code></dd></summary>
<hr>

src/utils/robust-query.ts

<li>Introduced new robust querying utility for consensus across nodes.<br> <li> Added custom equality logic for stake/unstake endpoints.<br> <li> Implemented retry, tally, and error handling mechanisms.<br> <li> Provided functions for robust API calls and active node discovery.


</details>


  </td>
  <td><a href="https://github.com/shardeum/shardeum-validator-cli/pull/65/files#diff-3783a6a32c64c34280cd4e683bb161d70ee29843b2d12ae99549468b6f4d13bc">+394/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>