### PR TITLE
SHARD-2698 fix: for not-yet created account, fetch stake details goes out of retries. added simple balance check.

### DIFF
--- a/src/node-commands.ts
+++ b/src/node-commands.ts
@@ -863,12 +863,25 @@ export function registerNodeCommands(program: Command) {
 
         const walletWithProvider = new ethers.Wallet(privateKey, provider)
 
+        const balance = await walletWithProvider.getBalance()
+        const stakeValueBN = ethers.utils.parseEther(stakeValue)
+
+        if (balance < stakeValueBN) {
+          const deficit = stakeValueBN.sub(balance)
+          console.error(
+            `Insufficient balance. Minimum Required Stake: ${stakeValue} SHM. Your balance: ${ethers.utils.formatEther(
+              balance
+            )}. Please add ${ethers.utils.formatEther(deficit)} SHM (plus some gas) to your wallet.`
+          )
+          process.exit(1)
+        }
+
         const [{ stakeRequired }, eoaData] = await Promise.all([
           fetchStakeParameters(config),
           fetchEOADetails(config, walletWithProvider.address),
         ])
 
-        if (ethers.BigNumber.from(stakeRequired).gt(ethers.utils.parseEther(stakeValue))) {
+        if (ethers.BigNumber.from(stakeRequired).gt(stakeValueBN)) {
           if (eoaData == null) {
             /*prettier-ignore*/
             console.error(`Stake amount must be greater than ${ethers.utils.formatEther(stakeRequired)} SHM`);

--- a/src/node-commands.ts
+++ b/src/node-commands.ts
@@ -866,7 +866,7 @@ export function registerNodeCommands(program: Command) {
         const balance = await walletWithProvider.getBalance()
         const stakeValueBN = ethers.utils.parseEther(stakeValue)
 
-        if (balance < stakeValueBN) {
+        if (balance.lt(stakeValueBN)) {
           const deficit = stakeValueBN.sub(balance)
           console.error(
             `Insufficient balance. Minimum Required Stake: ${stakeValue} SHM. Your balance: ${ethers.utils.formatEther(


### PR DESCRIPTION
### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Added balance check before staking to prevent retries.

- Improved error message for insufficient balance.

- Refactored stake value handling for clarity.

- Prevented unnecessary stake detail fetch for new accounts.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>node-commands.ts</strong><dd><code>Add pre-stake balance check and improve error handling</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/node-commands.ts

<li>Added wallet balance check before staking operation.<br> <li> Provided clear error message and exit on insufficient funds.<br> <li> Refactored stake value to use BigNumber for consistency.<br> <li> Prevented stake detail fetch retries for accounts without enough <br>balance.


</details>


  </td>
  <td><a href="https://github.com/shardeum/shardeum-validator-cli/pull/73/files#diff-16e6e49d3bbc5c66140d8f145f7990ca668256de32ecb0a0da81774b14d0b889">+14/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>